### PR TITLE
feat: standarize auth calls and fix flickering

### DIFF
--- a/src/lib/auth.ts
+++ b/src/lib/auth.ts
@@ -30,14 +30,6 @@ export async function setAuthOnResponse(userId: string) {
   await session.update((user: UserSession) => ((user.userId = userId), user));
 }
 
-export async function requireAuth() {
-  let userId = await getAuthUser();
-  if (!userId) {
-    await logoutSession();
-  }
-  return userId;
-}
-
 export async function logoutSession() {
   const session = await getSession();
   await session.update((user: UserSession) => (user.userId = undefined));

--- a/src/routes/board/[id].tsx
+++ b/src/routes/board/[id].tsx
@@ -19,7 +19,7 @@ const fetchBoard = cache(async (boardId: number) => {
   "use server";
   const accountId = await getAuthUser();
 
-  if (!accountId) throw redirect("/");
+  if (!accountId) throw redirect("/login");
 
   const boardFromDataBase = await db.board.findUnique({
     where: {


### PR DESCRIPTION
# What does it do?

- because of the redirect, there was some flickering when accessing auth routes when not authenticated this should not happen
- standardizes the use of the getAuthUser function everywhere instead of calling getSession 
- deletes unused function